### PR TITLE
feat: Add support for optional dependencies

### DIFF
--- a/src/hatch_cada/pyproject.py
+++ b/src/hatch_cada/pyproject.py
@@ -42,8 +42,13 @@ class Pyproject:
         return Version(metadata.version)
 
     @property
-    def requirements(self) -> list[Requirement]:
+    def dependencies(self) -> list[Requirement]:
         return [Requirement(dep) for dep in self._content.get("project", {}).get("dependencies", [])]
+
+    @property
+    def optional_dependencies(self) -> dict[str, list[Requirement]]:
+        opt_deps = self._content.get("project", {}).get("optional-dependencies", {})
+        return {group: [Requirement(dep) for dep in deps] for group, deps in opt_deps.items()}
 
     @property
     def members(self) -> list[str]:

--- a/tests/unit/test_pyproject.py
+++ b/tests/unit/test_pyproject.py
@@ -79,7 +79,7 @@ class TestRequirements:
 
         pyproject = Pyproject.load(pyproject_path)
 
-        assert pyproject.requirements == [Requirement("requests>=2.0"), Requirement("click")]
+        assert pyproject.dependencies == [Requirement("requests>=2.0"), Requirement("click")]
 
     def test_returns_empty_list_when_no_dependencies(self, tmp_path: Path) -> None:
         pyproject_path = tmp_path / "pyproject.toml"
@@ -87,7 +87,7 @@ class TestRequirements:
 
         pyproject = Pyproject.load(pyproject_path)
 
-        assert pyproject.requirements == []
+        assert pyproject.dependencies == []
 
 
 class TestMembers:


### PR DESCRIPTION
## Description

Add support for rewriting workspace dependencies in `project.optional-dependencies`. Previously, only dependencies listed in `project.dependencies` were processed. This change extends the metadata hook to also handle optional dependency groups (e.g., `dev`, `test`).

Closes #1

## Release Note

<!-- RELEASE_NOTE:START -->
Add support for `project.optional-dependencies`. Workspace dependencies in optional dependency groups are now rewritten with version specifiers during build.
<!-- RELEASE_NOTE:END -->