### PR TITLE
ci: Add test report and coverage upload workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -32,11 +30,14 @@ jobs:
       - name: Run tests with coverage
         run: uv run poe test
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
-          files: coverage.xml
-          flags: python${{ matrix.python-version }}
+          name: test-report-${{ matrix.python-version }}
+          path: |
+            report.xml
+            coverage.xml
 
   lint:
     name: Lint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,54 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  find-run:
+    name: Find CI run
+    runs-on: ubuntu-latest
+    outputs:
+      run-id: ${{ steps.find.outputs.run-id }}
+    steps:
+      - name: Find CI workflow run for merged PR
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find the PR that was merged with this commit
+          pr_number=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number')
+          echo "PR number: $pr_number"
+
+          # Find the CI workflow run for that PR's head commit
+          run_id=$(gh api "/repos/${{ github.repository }}/actions/workflows/ci.yml/runs?event=pull_request&status=success" \
+            --jq ".workflow_runs[] | select(.pull_requests[].number == $pr_number) | .id" | head -1)
+          echo "CI run ID: $run_id"
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+
+  upload:
+    name: Upload (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: find-run
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: test-report-${{ matrix.python-version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ needs.find-run.outputs.run-id }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: python${{ matrix.python-version }}

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,30 @@
+name: Test Report
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    name: Report (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Publish test results
+        uses: dorny/test-reporter@v2
+        with:
+          artifact: test-report-${{ matrix.python-version }}
+          name: Test Results (Python ${{ matrix.python-version }})
+          path: report.xml
+          reporter: java-junit

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+report.xml
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ sequence = [
 help = "Set up development environment"
 
 [tool.poe.tasks.test]
-cmd = "pytest --cov --cov-report=xml --cov-fail-under=100"
+cmd = "uv run pytest --cov --cov-report=xml --cov-report=term-missing --cov-fail-under=100 --junitxml=report.xml"
 help = "Run tests"
 
 [tool.poe.tasks.lint]


### PR DESCRIPTION
## Description

- Run CI only on `pull_request` to avoid duplicate test runs
- Add test-report workflow using dorny/test-reporter with `workflow_run` trigger for fork PR support
- Add coverage workflow that uploads to Codecov after PR merge by finding and downloading artifacts from the CI run