### PR TITLE
ci: Override Codecov commit and branch for proper baseline tracking

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,3 +56,5 @@ jobs:
         with:
           files: coverage.xml
           flags: python${{ matrix.python-version }}
+          override_commit: ${{ github.sha }}
+          override_branch: main


### PR DESCRIPTION
## Description

Without explicit overrides, Codecov wasn't associating the uploaded coverage with the main branch baseline.