### PR TITLE
ci: Add Codecov token and disable auto-search

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Wait for GitHub API to index the merge
+          sleep 10
+
           # Find the PR that was merged with this commit
           pr_number=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number')
           echo "PR number: $pr_number"
@@ -54,7 +57,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: python${{ matrix.python-version }}
           override_commit: ${{ github.sha }}
           override_branch: main
+          disable_search: true


### PR DESCRIPTION
## Description

- Use `CODECOV_TOKEN` for reliable uploads
- Disable auto-search to only upload the specified `coverage.xml` file