### PR TITLE
fix: Handle missing packages in lockfile during `uv add`

### DIFF
--- a/src/hatch_cada/hook.py
+++ b/src/hatch_cada/hook.py
@@ -61,7 +61,7 @@ class CadaMetaHook(MetadataHookInterface):
             new_deps: list[str] = []
             for req in dependencies:
                 pkg = lockfile.get_package(req.name)
-                if pkg.editable_path and any(fnmatch(pkg.editable_path, pattern) for pattern in member_patterns):
+                if pkg and pkg.editable_path and any(fnmatch(pkg.editable_path, p) for p in member_patterns):
                     strategy = overrides.get(req.name, default_strategy)
                     req.specifier = strategy.make_specifier(pkg.version)
                 new_deps.append(str(req))
@@ -73,7 +73,7 @@ class CadaMetaHook(MetadataHookInterface):
                 new_group_deps: list[str] = []
                 for req in reqs:
                     pkg = lockfile.get_package(req.name)
-                    if pkg.editable_path and any(fnmatch(pkg.editable_path, pattern) for pattern in member_patterns):
+                    if pkg and pkg.editable_path and any(fnmatch(pkg.editable_path, p) for p in member_patterns):
                         strategy = overrides.get(req.name, default_strategy)
                         req.specifier = strategy.make_specifier(pkg.version)
                     new_group_deps.append(str(req))

--- a/src/hatch_cada/lockfile.py
+++ b/src/hatch_cada/lockfile.py
@@ -66,20 +66,19 @@ class Lockfile:
     def _packages(self) -> dict:
         return {pkg["name"]: pkg for pkg in self._content.get("package", [])}
 
-    def get_package(self, name: str) -> Package:
+    def get_package(self, name: str) -> Package | None:
         """Get a package from the lockfile.
 
         Args:
             name: The package name to look up.
 
         Returns:
-            The package with resolved version.
-
-        Raises:
-            KeyError: If the package is not found.
+            The package with resolved version, or None if not found.
+            Returns None during `uv add` when the lockfile may not yet
+            contain the package being added.
         """
         entry = self._packages.get(name)
         if entry is None:
-            raise KeyError(f"Package '{name}' not found in lockfile")
+            return None
 
         return Package.from_lock_entry(entry, self._root)

--- a/tests/unit/test_lockfile.py
+++ b/tests/unit/test_lockfile.py
@@ -68,7 +68,7 @@ class TestGetPackage:
 
         assert pkg == Package(name="mylib", version=Version("3.5.0"), editable_path="packages/mylib")
 
-    def test_raises_for_missing_package(self, tmp_path: Path) -> None:
+    def test_returns_none_for_missing_package(self, tmp_path: Path) -> None:
         lock_content = textwrap.dedent("""
             version = 1
 
@@ -81,8 +81,7 @@ class TestGetPackage:
 
         lockfile = Lockfile.load(lock_path)
 
-        with pytest.raises(KeyError, match="Package 'nonexistent' not found"):
-            lockfile.get_package("nonexistent")
+        assert lockfile.get_package("nonexistent") is None
 
     def test_raises_for_package_without_version_or_editable(self, tmp_path: Path) -> None:
         lock_content = textwrap.dedent("""


### PR DESCRIPTION
## Description

When running `uv add`, the metadata hook is triggered before the new package is written to the lockfile, causing a KeyError. Changed `get_package()` to return `None` instead of raising, allowing the hook to gracefully skip packages not yet in the lockfile.

## Release Note

<!--
Optional: Add a user-facing release note for this change.

Notes:
- This will appear in the changelog as the commit body.
- Markdown formatting is supported.
- Leave this section empty if you don’t want anything beyond the PR title to appear in the changelog.
- Do not remove the RELEASE_NOTE:START and RELEASE_NOTE:END tags.
-->

<!-- RELEASE_NOTE:START -->
Fixed `KeyError` when running `uv add`. The metadata hook now gracefully handles packages not
   yet present in the lockfile.
<!-- RELEASE_NOTE:END -->
