### PR TITLE
ci: remove multi-ecosystem groups for semantic PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,27 @@
 version: 2
 
-multi-ecosystem-groups:
-  python:
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - dependencies
-    assignees:
-      - bilelomrani1
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
 
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    multi-ecosystem-group: python
-    patterns: ["*"]
-    versioning-strategy: increase-if-necessary
-
   - package-ecosystem: "uv"
     directory: "/"
-    multi-ecosystem-group: python
-    patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -31,8 +29,6 @@ updates:
       interval: "weekly"
     labels:
       - dependencies
-    assignees:
-      - bilelomrani1
     commit-message:
       prefix: "chore"
       prefix-development: "chore"


### PR DESCRIPTION
## Description

Dependabot's multi-ecosystem-groups feature bypasses the commit-message configuration, resulting in non-semantic PR titles. This caused CI failures on the semantic PR check and incorrect merge commit messages.

Switching to individual PRs per dependency allows the commit-message config to work properly, generating semantic titles like "chore(deps): bump package from X to Y".

Also removes assignees to reduce notification noise.

## Release Note

<!-- RELEASE_NOTE:START -->

<!-- RELEASE_NOTE:END -->