### PR TITLE
ci: add self-hosted Renovate workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":enablePreCommit"],
+  "onboarding": false,
+  "requireConfig": "optional",
+  "branchPrefix": "renovate/",
   "labels": ["dependencies"],
   "ignoreDeps": ["python"],
   "rebaseWhen": "behind-base-branch",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,29 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 4 * * 1,2" # Monday & Tuesday 4am UTC
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run in dry-run mode (no PRs created)"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v44.2.6
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || 'null' }}
+          RENOVATE_REPOSITORY_CACHE: enabled
+          LOG_LEVEL: info


### PR DESCRIPTION
## Description

Add GitHub Actions workflow to run Renovate in self-hosted mode for private repos or repos without the Renovate GitHub App.

**Changes:**
- Add `.github/workflows/renovate.yml` workflow
  - Runs Monday & Tuesday 4am UTC (matching config schedules)
  - Manual trigger with dry-run option for testing
  - Repository cache enabled for faster runs
  - Pinned to `renovatebot/github-action@v44.2.6`
- Update `renovate.json` for self-hosted mode
  - `onboarding: false` - skip onboarding PR
  - `requireConfig: "optional"` - don't require per-repo config
  - `branchPrefix: "renovate/"` - consistent branch naming

**Setup required:**
1. Create a PAT with `repo` scope
2. Add it as `RENOVATE_TOKEN` in repo secrets (Settings → Secrets → Actions)

## Release Note

<!-- RELEASE_NOTE:START -->

<!-- RELEASE_NOTE:END -->