### PR TITLE
ci: fix Renovate workflow and add debugging options

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
   "commitMessageAction": "bump",
   "packageRules": [
     {
-      "matchManagers": ["pep621", "pip_requirements", "uv"],
+      "matchManagers": ["pep621", "pip_requirements"],
       "groupName": "Python dependencies",
       "commitMessagePrefix": "chore(deps): "
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":enablePreCommit"],
-  "onboarding": false,
-  "requireConfig": "optional",
   "branchPrefix": "renovate/",
   "labels": ["dependencies"],
   "ignoreDeps": ["python"],
@@ -13,8 +11,7 @@
     "enabled": true,
     "schedule": ["before 5am on tuesday"]
   },
-  "osvVulnerabilityAlerts": true,
-  "commitMessagePrefix": "chore(deps): ",
+    "commitMessagePrefix": "chore(deps): ",
   "commitMessageAction": "bump",
   "packageRules": [
     {

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,6 +24,7 @@ jobs:
           configurationFile: .github/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || 'null' }}
           RENOVATE_REPOSITORY_CACHE: enabled
           LOG_LEVEL: info

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,6 +10,14 @@ on:
         required: false
         default: false
         type: boolean
+      log-level:
+        description: "Log level (info or debug)"
+        required: false
+        default: "info"
+        type: choice
+        options:
+          - info
+          - debug
 
 jobs:
   renovate:
@@ -29,4 +37,4 @@ jobs:
           RENOVATE_REQUIRE_CONFIG: optional
           RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || 'null' }}
           RENOVATE_REPOSITORY_CACHE: enabled
-          LOG_LEVEL: info
+          LOG_LEVEL: ${{ inputs.log-level || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,6 +25,8 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_REQUIRE_CONFIG: optional
           RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || 'null' }}
           RENOVATE_REPOSITORY_CACHE: enabled
           LOG_LEVEL: info

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,6 +18,11 @@ on:
         options:
           - info
           - debug
+      force:
+        description: "Force run (ignore schedule)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   renovate:
@@ -36,5 +41,6 @@ jobs:
           RENOVATE_ONBOARDING: "false"
           RENOVATE_REQUIRE_CONFIG: optional
           RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || 'null' }}
+          RENOVATE_FORCE: ${{ inputs.force && '{"schedule":null}' || 'null' }}
           RENOVATE_REPOSITORY_CACHE: enabled
           LOG_LEVEL: ${{ inputs.log-level || 'info' }}


### PR DESCRIPTION
## Description

Fixes and improvements to the self-hosted Renovate workflow based on testing.

**Fixes:**
- Add `RENOVATE_REPOSITORIES` env var (was missing, causing "no repositories found" error)
- Move `onboarding` and `requireConfig` from `renovate.json` to workflow env vars (they are global-only options)
- Remove invalid `uv` manager from packageRules (`pep621` handles uv.lock automatically)

**New features:**
- `log-level` input: Switch between `info` and `debug` for troubleshooting
- `force` input: Bypass schedule restrictions for immediate testing

**Verified working:**
- Detects `uv.lock` via `pep621` manager
- Would create PRs for: `python-dependencies`, `github-actions`, `pre-commit-hooks`
- Lock file maintenance scheduled for Tuesdays

## Release Note

<!-- RELEASE_NOTE:START -->

<!-- RELEASE_NOTE:END -->