### PR TITLE
chore: increase Renovate prHourlyLimit to 5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   "labels": ["dependencies"],
   "ignoreDeps": ["python"],
   "rebaseWhen": "behind-base-branch",
+  "prHourlyLimit": 5,
   "schedule": ["before 5am on monday"],
   "minimumReleaseAge": "3 days",
   "lockFileMaintenance": {


### PR DESCRIPTION
Increase from default (2) to avoid rate-limiting lockFileMaintenance and grouped updates.