### PR TITLE
fix: Handle directory path dependencies in lockfile

### DIFF
--- a/src/hatch_cada/lockfile.py
+++ b/src/hatch_cada/lockfile.py
@@ -39,12 +39,16 @@ class Package:
             KeyError: If the package has no version and is not editable.
         """
         name = entry["name"]
-        editable_path = entry.get("source", {}).get("editable")
+        source = entry.get("source", {})
+        editable_path = source.get("editable")
+        directory_path = source.get("directory")
 
         if "version" in entry:
             version = Version(entry["version"])
         elif editable_path:
             version = Pyproject.load(root / editable_path / PYPROJECT_NAME).version
+        elif directory_path:
+            version = Pyproject.load(root / directory_path / PYPROJECT_NAME).version
         else:
             raise KeyError(f"Package '{name}' has no version and is not editable")
 

--- a/tests/unit/test_lockfile.py
+++ b/tests/unit/test_lockfile.py
@@ -83,6 +83,33 @@ class TestGetPackage:
 
         assert lockfile.get_package("nonexistent") is None
 
+    def test_returns_package_with_directory_path(self, tmp_path: Path) -> None:
+        pkg_dir = tmp_path / ".." / "extlib"
+        pkg_dir = pkg_dir.resolve()
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "pyproject.toml").write_text(
+            textwrap.dedent("""
+                [project]
+                name = "extlib"
+                version = "1.2.3"
+            """)
+        )
+
+        lock_content = textwrap.dedent("""
+            version = 1
+
+            [[package]]
+            name = "extlib"
+            source = { directory = "../extlib" }
+        """)
+        lock_path = tmp_path / "uv.lock"
+        lock_path.write_text(lock_content)
+
+        lockfile = Lockfile.load(lock_path)
+        pkg = lockfile.get_package("extlib")
+
+        assert pkg == Package(name="extlib", version=Version("1.2.3"), editable_path=None)
+
     def test_raises_for_package_without_version_or_editable(self, tmp_path: Path) -> None:
         lock_content = textwrap.dedent("""
             version = 1


### PR DESCRIPTION
## Description

uv uses `source = { directory = "..." }` for `file://` path dependencies (non-workspace local packages). These entries may omit `version` from the lockfile when the package uses dynamic versioning (e.g. `hatch-vcs`). `Package.from_lock_entry` only checked `source.editable`, causing a `KeyError` for any such dependency.

This PR extends `from_lock_entry` to also handle `source.directory` by loading the version from the package's `pyproject.toml` — the same resolution logic used for editable packages. `editable_path` is left as `None` for directory packages so the hook does not rewrite their specifiers (only workspace members matched via `fnmatch` should be rewritten).

## Release Note

<!-- RELEASE_NOTE:START -->
Support `source.directory` (file:// path dependencies) in the lockfile parser. Previously, packages declared as `file://` path dependencies would raise a `KeyError` if their version was omitted from the lockfile.
<!-- RELEASE_NOTE:END -->