### PR TITLE
fix: Handle circular workspace dependencies

### DIFF
--- a/src/hatch_cada/hook.py
+++ b/src/hatch_cada/hook.py
@@ -17,6 +17,14 @@ class CadaMetaHook(MetadataHookInterface):
 
     PLUGIN_NAME = "cada"
 
+    # Packages currently being resolved. When resolving an editable dependency's
+    # version, hatchling may trigger this hook again for that dependency. If it
+    # in turn depends back on a package already being resolved, we'd recurse
+    # infinitely. Skipping re-entrant calls is safe because the caller only
+    # needs the version, which is resolved by the version source plugin
+    # independently of metadata hooks.
+    _resolving: set[str] = set()
+
     def update(self, metadata: dict) -> None:
         """Rewrite workspace dependencies with version constraints.
 
@@ -26,59 +34,67 @@ class CadaMetaHook(MetadataHookInterface):
         Raises:
             ValueError: If strategy is missing or invalid.
         """
-        if "strategy" not in self.config:
-            valid = ", ".join(s.value for s in Strategy)
-            raise ValueError(
-                f"Missing required 'strategy' option. "
-                f"Add to pyproject.toml:\n\n"
-                f"[tool.hatch.metadata.hooks.cada]\n"
-                f'strategy = "allow-all-updates"\n\n'
-                f"Valid strategies: {valid}"
-            )
-
-        default_strategy = Strategy.from_string(self.config["strategy"])
-        overrides = {name: Strategy.from_string(value) for name, value in self.config.get("overrides", {}).items()}
-
-        pkg_pyproject = Pyproject.load(Path(self.root) / PYPROJECT_NAME)
-        dependencies = pkg_pyproject.dependencies
-        optional_dependencies = pkg_pyproject.optional_dependencies
-
-        workspace_root = find_workspace_root(Path(self.root))
-        if workspace_root is None:
-            warnings.warn(
-                f"No workspace found for {self.root}. "
-                f"Workspace dependencies will not be rewritten. "
-                f"Set WORKSPACE_ROOT or ensure uv.lock exists in a parent directory.",
-                stacklevel=2,
-            )
+        pkg_name = metadata.get("name", "")
+        if pkg_name in self._resolving:
             return
 
-        workspace_pyproject = Pyproject.load(workspace_root / PYPROJECT_NAME)
-        lockfile = Lockfile.load(workspace_root / UV_LOCKFILE_NAME)
-        member_patterns = workspace_pyproject.members
+        self._resolving.add(pkg_name)
+        try:
+            if "strategy" not in self.config:
+                valid = ", ".join(s.value for s in Strategy)
+                raise ValueError(
+                    f"Missing required 'strategy' option. "
+                    f"Add to pyproject.toml:\n\n"
+                    f"[tool.hatch.metadata.hooks.cada]\n"
+                    f'strategy = "allow-all-updates"\n\n'
+                    f"Valid strategies: {valid}"
+                )
 
-        if dependencies:
-            new_deps: list[str] = []
-            for req in dependencies:
-                pkg = lockfile.get_package(req.name)
-                if pkg and pkg.editable_path and any(fnmatch(pkg.editable_path, p) for p in member_patterns):
-                    strategy = overrides.get(req.name, default_strategy)
-                    req.specifier = strategy.make_specifier(pkg.version)
-                new_deps.append(str(req))
-            metadata["dependencies"] = new_deps
+            default_strategy = Strategy.from_string(self.config["strategy"])
+            overrides = {name: Strategy.from_string(value) for name, value in self.config.get("overrides", {}).items()}
 
-        if optional_dependencies:
-            new_opt_deps: dict[str, list[str]] = {}
-            for group, reqs in optional_dependencies.items():
-                new_group_deps: list[str] = []
-                for req in reqs:
+            pkg_pyproject = Pyproject.load(Path(self.root) / PYPROJECT_NAME)
+            dependencies = pkg_pyproject.dependencies
+            optional_dependencies = pkg_pyproject.optional_dependencies
+
+            workspace_root = find_workspace_root(Path(self.root))
+            if workspace_root is None:
+                warnings.warn(
+                    f"No workspace found for {self.root}. "
+                    f"Workspace dependencies will not be rewritten. "
+                    f"Set WORKSPACE_ROOT or ensure uv.lock exists in a parent directory.",
+                    stacklevel=2,
+                )
+                return
+
+            workspace_pyproject = Pyproject.load(workspace_root / PYPROJECT_NAME)
+            lockfile = Lockfile.load(workspace_root / UV_LOCKFILE_NAME)
+            member_patterns = workspace_pyproject.members
+
+            if dependencies:
+                new_deps: list[str] = []
+                for req in dependencies:
                     pkg = lockfile.get_package(req.name)
                     if pkg and pkg.editable_path and any(fnmatch(pkg.editable_path, p) for p in member_patterns):
                         strategy = overrides.get(req.name, default_strategy)
                         req.specifier = strategy.make_specifier(pkg.version)
-                    new_group_deps.append(str(req))
-                new_opt_deps[group] = new_group_deps
-            metadata["optional-dependencies"] = new_opt_deps
+                    new_deps.append(str(req))
+                metadata["dependencies"] = new_deps
+
+            if optional_dependencies:
+                new_opt_deps: dict[str, list[str]] = {}
+                for group, reqs in optional_dependencies.items():
+                    new_group_deps: list[str] = []
+                    for req in reqs:
+                        pkg = lockfile.get_package(req.name)
+                        if pkg and pkg.editable_path and any(fnmatch(pkg.editable_path, p) for p in member_patterns):
+                            strategy = overrides.get(req.name, default_strategy)
+                            req.specifier = strategy.make_specifier(pkg.version)
+                        new_group_deps.append(str(req))
+                    new_opt_deps[group] = new_group_deps
+                metadata["optional-dependencies"] = new_opt_deps
+        finally:
+            self._resolving.discard(pkg_name)
 
 
 @hookimpl

--- a/tests/unit/test_hook.py
+++ b/tests/unit/test_hook.py
@@ -21,9 +21,25 @@ class WorkspacePackage:
     version: str
     dependencies: list[str] = field(default_factory=list)
     optional_dependencies: dict[str, list[str]] = field(default_factory=dict)
+    dynamic: bool = False
 
     def pyproject(self) -> str:
-        data: dict[str, Any] = {"project": {"name": self.name, "version": self.version}}
+        data: dict[str, Any] = {"project": {"name": self.name}}
+        if self.dynamic:
+            data["project"]["dynamic"] = ["version"]
+            data["project"]["requires-python"] = ">=3.10"
+            data["build-system"] = {
+                "requires": ["hatchling", "hatch-cada"],
+                "build-backend": "hatchling.build",
+            }
+            data["tool"] = {
+                "hatch": {
+                    "version": {"path": "_version.py"},
+                    "metadata": {"hooks": {"cada": {"strategy": "pin"}}},
+                },
+            }
+        else:
+            data["project"]["version"] = self.version
         if self.dependencies:
             data["project"]["dependencies"] = self.dependencies
         if self.optional_dependencies:
@@ -51,7 +67,12 @@ class WorkspaceConfig:
                 [
                     "[[package]]",
                     f'name = "{pkg.name}"',
-                    f'version = "{pkg.version}"',
+                ]
+            )
+            if not pkg.dynamic:
+                lines.append(f'version = "{pkg.version}"')
+            lines.extend(
+                [
                     f'source = {{ editable = "{pkg.name}" }}',
                     "",
                 ]
@@ -82,6 +103,8 @@ def workspace_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Worksp
             pkg_path = workspace_root / pkg.name
             pkg_path.mkdir(parents=True, exist_ok=True)
             (pkg_path / "pyproject.toml").write_text(pkg.pyproject())
+            if pkg.dynamic:
+                (pkg_path / "_version.py").write_text(f'__version__ = "{pkg.version}"\n')
         (workspace_root / "uv.lock").write_text(config.lockfile())
         monkeypatch.setenv("WORKSPACE_ROOT", str(workspace_root))
         return workspace_root
@@ -288,3 +311,35 @@ class TestCadaMetaHook:
         hook.update(metadata)
 
         assert metadata == expected_metadata
+
+    def test_circular_optional_deps_with_dynamic_versions(self, workspace_factory: WorkspaceFactory) -> None:
+        workspace = workspace_factory(
+            WorkspaceConfig(
+                packages=[
+                    WorkspacePackage("pkg-a", "1.0.0", optional_dependencies={"with-b": ["pkg-b"]}, dynamic=True),
+                    WorkspacePackage("pkg-b", "2.0.0", optional_dependencies={"with-a": ["pkg-a"]}, dynamic=True),
+                ]
+            )
+        )
+        hook = create_hook(workspace / "pkg-a", {"strategy": "pin"})
+        metadata: dict[str, Any] = {"name": "pkg-a"}
+
+        hook.update(metadata)
+
+        assert metadata == {"name": "pkg-a", "optional-dependencies": {"with-b": ["pkg-b==2.0.0"]}}
+
+    def test_circular_direct_deps_with_dynamic_versions(self, workspace_factory: WorkspaceFactory) -> None:
+        workspace = workspace_factory(
+            WorkspaceConfig(
+                packages=[
+                    WorkspacePackage("pkg-a", "1.0.0", dependencies=["pkg-b"], dynamic=True),
+                    WorkspacePackage("pkg-b", "2.0.0", dependencies=["pkg-a"], dynamic=True),
+                ]
+            )
+        )
+        hook = create_hook(workspace / "pkg-a", {"strategy": "pin"})
+        metadata: dict[str, Any] = {"name": "pkg-a"}
+
+        hook.update(metadata)
+
+        assert metadata == {"name": "pkg-a", "dependencies": ["pkg-b==2.0.0"]}


### PR DESCRIPTION
## Description

When two editable workspace packages depend on each other (directly or via optional deps) and both use hatch-cada with dynamic versions, resolving one package's version triggers hatch-cada for the other, which triggers it back — causing a `RecursionError`.

This adds a re-entrancy guard to `CadaMetaHook.update()` that skips dependency rewriting when a package is already being resolved in the call stack. Skipping is safe because the nested call only needs the version, which is resolved by the version source plugin independently of metadata hooks.

## Release Note

<!-- RELEASE_NOTE:START -->

Fixed `RecursionError` when workspace packages with dynamic versions have circular dependencies and both use hatch-cada.

<!-- RELEASE_NOTE:END -->